### PR TITLE
fix: change margin for edit-link element

### DIFF
--- a/assets/styles/layouts/_content.scss
+++ b/assets/styles/layouts/_content.scss
@@ -28,7 +28,7 @@
 }
 
 .edit-link {
-  margin-top: 5rem;
+  margin-bottom: 2rem;
 }
 
 // Print


### PR DESCRIPTION
Partial fix for https://github.com/pressbooks/ideas/issues/420. Accompanies https://github.com/pressbooks/pressbooks-book/pull/1156