### PR TITLE
fix: focus state radio

### DIFF
--- a/assets/styles/layouts/_page-sections.scss
+++ b/assets/styles/layouts/_page-sections.scss
@@ -66,7 +66,6 @@
     justify-content: center;
     width: 3rem;
     height: 3rem;
-    cursor: pointer;
   }
 }
 
@@ -83,7 +82,6 @@
 
 .block-toggle__cta__button {
   bottom: 0;
-  cursor: pointer;
   font-size: 1.5rem;
   left: 50%;
   margin: 0;
@@ -104,7 +102,7 @@
   }
 
   &:hover {
-    color: var(--primary);
+    color: var(--primary-dark);
   }
 }
 

--- a/assets/styles/layouts/_page-sections.scss
+++ b/assets/styles/layouts/_page-sections.scss
@@ -57,13 +57,16 @@
   }
 
   button {
+    display: inline-flex;
     background-color: unset;
-    border: 0;
+    border: none;
     border-radius: 50%;
-    padding: 10px 0 0;
+    padding: 0;
     align-items: center;
     justify-content: center;
     width: 3rem;
+    height: 3rem;
+    cursor: pointer;
   }
 }
 

--- a/assets/styles/layouts/_page-sections.scss
+++ b/assets/styles/layouts/_page-sections.scss
@@ -102,6 +102,10 @@
       transform: rotate(180deg);
     }
   }
+
+  &:hover {
+    color: var(--primary);
+  }
 }
 
 .block.block-toggle {


### PR DESCRIPTION
It fixes point 2 from: https://github.com/pressbooks/pressbooks-book/pull/1319#issuecomment-2742002159

This pull request includes changes to the `assets/styles/layouts/_page-sections.scss` file to improve the styling of buttons. The most important changes include modifying the button display property, adjusting the border and padding, and adding new properties for height and cursor.

Styling improvements for buttons:

* Changed the button display property to `inline-flex` for better alignment and layout.
* Updated the border property from `0` to `none` for consistency.
* Adjusted padding from `10px 0 0` to `0` to eliminate unnecessary space.
* Added height property with value `3rem` to ensure consistent button size.
* Added cursor property set to `pointer` to indicate clickable buttons.